### PR TITLE
Add AWS Config ListTags event type to CloudTrailChange logfilter to s…

### DIFF
--- a/templates/cloudtrail-baseline.yml
+++ b/templates/cloudtrail-baseline.yml
@@ -261,7 +261,7 @@ Resources:
         Type: AWS::Logs::MetricFilter
         Properties:
             LogGroupName: !Ref rCloudTrailLogGroup
-            FilterPattern: '{($.eventSource = cloudtrail.amazonaws.com) && (($.eventName != Describe*) && ($.eventName != Get*) && ($.eventName != Lookup*) && ($.eventName != Lookup*))}'
+            FilterPattern: '{($.eventSource = cloudtrail.amazonaws.com) && (($.eventName != Describe*) && ($.eventName != Get*) && ($.eventName != Lookup*) && ($.eventName != ListTags*))}'
             MetricTransformations:
               - MetricNamespace: CloudTrailMetrics
                 MetricName: CloudTrailChangeCount


### PR DESCRIPTION
…uppress false positive alarms.

*Issue #, if available:*

*Description of changes:*
Removed duplicate filtering for "$.eventName !=  Lookup*" and replaced by "$.eventName != ListTags*", which is issued by AWS Config. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
