### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/templates/aws-cross-account-manager-master.yml
+++ b/templates/aws-cross-account-manager-master.yml
@@ -82,7 +82,7 @@ Resources:
         Fn::GetAtt:
         - AccessLinksHandlerExecRole
         - Arn
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Timeout: '300'
     Type: AWS::Lambda::Function
   AccessLinksHandlerExecRole:
@@ -169,7 +169,7 @@ Resources:
         Fn::GetAtt:
         - AccountEventHandlerExecRole
         - Arn
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Timeout: '300'
     Type: AWS::Lambda::Function
   AccountEventHandlerExecRole:
@@ -211,7 +211,7 @@ Resources:
         Fn::GetAtt:
         - AccountFileHandlerExecRole
         - Arn
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Timeout: '300'
     Type: AWS::Lambda::Function
   AccountFileHandlerExecRole:
@@ -630,7 +630,7 @@ Resources:
         Fn::GetAtt:
         - InitMasterAccountExecRole
         - Arn
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Timeout: '60'
     Type: AWS::Lambda::Function
   InitMasterAccountCustomResource:
@@ -671,7 +671,7 @@ Resources:
         Fn::GetAtt:
         - RoleEventHandlerExecRole
         - Arn
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Timeout: '300'
     Type: AWS::Lambda::Function
   RoleEventHandlerExecRole:
@@ -725,7 +725,7 @@ Resources:
         Fn::GetAtt:
         - RoleFileHandlerExecRole
         - Arn
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Timeout: '300'
     Type: AWS::Lambda::Function
   RoleFileHandlerExecRole:

--- a/templates/aws-cross-account-manager-sub.yml
+++ b/templates/aws-cross-account-manager-sub.yml
@@ -85,7 +85,7 @@ Resources:
         Fn::GetAtt:
         - InitSubAccountExecRole
         - Arn
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Timeout: '60'
     Type: AWS::Lambda::Function
   InitSubAccountCustomResource:

--- a/templates/centralized-log-analytics.yml
+++ b/templates/centralized-log-analytics.yml
@@ -539,7 +539,7 @@ Resources:
         Fn::GetAtt:
         - LogStreamerRole
         - Arn
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Timeout: '300'
     Type: AWS::Lambda::Function
   LogStreamerRole:

--- a/templates/vpc-flow-logs_instance_logs.yml
+++ b/templates/vpc-flow-logs_instance_logs.yml
@@ -252,7 +252,7 @@ Resources:
         Fn::GetAtt:
         - LogStreamerRole
         - Arn
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Timeout: '300'
     Type: AWS::Lambda::Function
   LogStreamerRole:


### PR DESCRIPTION
CloudFormation templates in arc325-multiple-accounts-workshop have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.